### PR TITLE
fix: minor ui changes (navbar, homepage)

### DIFF
--- a/app/components/Nav/Nav.tsx
+++ b/app/components/Nav/Nav.tsx
@@ -38,7 +38,10 @@ export default function Nav() {
   const underlineTiming = 'cubic-bezier(0.35, 0, 0.25, 1)';
 
   const renderNavLinkContent = (label: string, isActive?: boolean) => (
-    <span className="relative inline-block leading-[25px]" style={{ boxSizing: 'content-box' }}>
+    <span
+      className="relative inline-block leading-[25px]"
+      style={{ boxSizing: 'content-box' }}
+    >
       <span>{label}</span>
       <span
         className={classNames(
@@ -87,7 +90,14 @@ export default function Nav() {
           </div>
           <nav className="flex items-center gap-[21.6px]">
             <Link to="https://brockcsc.ca/links" className="flex items-center">
-              <button className="inline-block bg-[#aa3b3b] px-6 pt-[6.75px] pb-[9px] text-lg font-normal text-[rgba(255,255,255,0.9)] cursor-pointer hover:bg-[#8e3232] leading-[20.7px] transition-[background-color] duration-200" style={{ boxSizing: 'content-box', fontFamily: 'sans-serif', transitionTimingFunction: 'cubic-bezier(0.35, 0, 0.25, 1)' }}>
+              <button
+                className="inline-block bg-[#aa3b3b] px-6 pt-[6.75px] pb-[9px] text-lg font-normal text-[rgba(255,255,255,0.9)] cursor-pointer hover:bg-[#8e3232] leading-[20.7px] transition-[background-color] duration-200"
+                style={{
+                  boxSizing: 'content-box',
+                  fontFamily: 'sans-serif',
+                  transitionTimingFunction: 'cubic-bezier(0.35, 0, 0.25, 1)',
+                }}
+              >
                 Join
               </button>
             </Link>
@@ -129,7 +139,14 @@ export default function Nav() {
               />
             </Link>
             <Link to="/links">
-              <button className="ml-8 inline-block bg-[#aa3b3b] px-10 pt-1.5 pb-2 text-base font-normal text-[rgba(255,255,255,0.9)] cursor-pointer hover:bg-[#8e3232] leading-[18.4px] transition-[background-color] duration-200" style={{ boxSizing: 'content-box', fontFamily: 'sans-serif', transitionTimingFunction: 'cubic-bezier(0.35, 0, 0.25, 1)' }}>
+              <button
+                className="ml-8 inline-block bg-[#aa3b3b] px-10 pt-1.5 pb-2 text-base font-normal text-[rgba(255,255,255,0.9)] cursor-pointer hover:bg-[#8e3232] leading-[18.4px] transition-[background-color] duration-200"
+                style={{
+                  boxSizing: 'content-box',
+                  fontFamily: 'sans-serif',
+                  transitionTimingFunction: 'cubic-bezier(0.35, 0, 0.25, 1)',
+                }}
+              >
                 Join
               </button>
             </Link>
@@ -140,7 +157,7 @@ export default function Nav() {
             aria-label="Toggle navigation menu"
             aria-expanded={showOverlay}
             onClick={() => setShowOverlay((prev) => !prev)}
-            style={{ 
+            style={{
               boxSizing: 'content-box',
               fontFamily: 'Lato, sans-serif',
               fontSize: '16px',
@@ -148,7 +165,7 @@ export default function Nav() {
               lineHeight: '25px',
               height: '15px',
               width: '20px',
-              perspective: '40px'
+              perspective: '40px',
             }}
           >
             <span className="sr-only">Open menu</span>

--- a/app/components/Nav/Nav.tsx
+++ b/app/components/Nav/Nav.tsx
@@ -4,9 +4,9 @@ import classNames from 'classnames';
 
 const NAV_SCROLL_THRESHOLD = 30;
 const navLinks = [
-  { href: '/', label: 'Merch', external: false },
   { href: 'https://brockcsc.ca/team', label: 'Team', external: false },
   { href: 'https://brockcsc.ca/events', label: 'Events', external: false },
+  { href: '/', label: 'Merch', external: false },
   { href: 'https://brockcsc.ca/guide', label: 'CS Guide', external: false },
   { href: 'https://brockcsc.ca/contact', label: 'Contact', external: false },
 ];
@@ -32,13 +32,13 @@ export default function Nav() {
   const isWhite = true;
 
   const navLinkBase =
-    'group relative inline-flex items-center text-[1.125rem] font-medium tracking-tight transition-colors duration-300';
+    'group relative inline-block text-[1.125rem] font-normal transition-all duration-300 ease -mt-[2px]';
   const navLinkColor = isWhite ? 'text-black/90' : 'text-white/90';
   const navLinkUnderlineColor = 'bg-[#aa3b3b]';
   const underlineTiming = 'cubic-bezier(0.35, 0, 0.25, 1)';
 
   const renderNavLinkContent = (label: string, isActive?: boolean) => (
-    <span className="relative inline-flex items-center justify-center pb-1">
+    <span className="relative inline-block leading-[25px]" style={{ boxSizing: 'content-box' }}>
       <span>{label}</span>
       <span
         className={classNames(
@@ -56,7 +56,7 @@ export default function Nav() {
   const hamburgerLineColor =
     !showOverlay && isWhite ? 'rgba(0, 0, 0, 0.9)' : 'rgba(255, 255, 255, 0.9)';
   const hamburgerLineBase =
-    'absolute left-0 block h-[1px] w-6 transition-all duration-300 ease-in-out';
+    'absolute left-0 block h-[1px] w-5 transition-all duration-300 ease-in-out';
 
   return (
     <header className="sticky inset-x-0 top-0 z-20">
@@ -66,6 +66,7 @@ export default function Nav() {
           isWhite ? 'bg-white' : 'bg-transparent',
           isScrolled && 'shadow-[0px_7px_17px_-10px_rgba(0,0,0,0.4)]'
         )}
+        style={{ lineHeight: '18.4px' }}
       >
         <div
           className={classNames(
@@ -75,7 +76,7 @@ export default function Nav() {
         />
         <div className="hidden h-full w-[75%] max-w-[1280px] mx-auto items-center justify-between lg:flex">
           <div className="flex h-full items-center">
-            <a href="https://brockcsc.ca">
+            <a href="https://brockcsc.ca" className="flex items-center -mt-px">
               <img
                 width={75}
                 height={56}
@@ -84,9 +85,9 @@ export default function Nav() {
               />
             </a>
           </div>
-          <nav className="flex items-center gap-[1.2em]">
-            <Link to="/links">
-              <button className="inline-flex items-center justify-center bg-[#aa3b3b] px-6 py-1.5 text-base font-medium text-[rgba(255,255,255,0.9)] transition-colors duration-200 hover:bg-[#8e3232]">
+          <nav className="flex items-center gap-[21.6px]">
+            <Link to="https://brockcsc.ca/links" className="flex items-center">
+              <button className="inline-block bg-[#aa3b3b] px-6 pt-[6.75px] pb-[9px] text-lg font-normal text-[rgba(255,255,255,0.9)] cursor-pointer hover:bg-[#8e3232] leading-[20.7px] transition-[background-color] duration-200" style={{ boxSizing: 'content-box', fontFamily: 'sans-serif', transitionTimingFunction: 'cubic-bezier(0.35, 0, 0.25, 1)' }}>
                 Join
               </button>
             </Link>
@@ -99,6 +100,7 @@ export default function Nav() {
                   target="_blank"
                   rel="noopener noreferrer"
                   title={link.label}
+                  style={{ boxSizing: 'content-box' }}
                 >
                   {renderNavLinkContent(link.label)}
                 </a>
@@ -108,6 +110,7 @@ export default function Nav() {
                   to={link.href}
                   className={classNames(navLinkBase, navLinkColor)}
                   title={link.label}
+                  style={{ boxSizing: 'content-box' }}
                 >
                   {({ isActive }) => renderNavLinkContent(link.label, isActive)}
                 </NavLink>
@@ -115,9 +118,9 @@ export default function Nav() {
             )}
           </nav>
         </div>
-        <div className="flex h-full w-full items-center justify-between px-4 lg:hidden">
+        <div className="flex h-full w-full items-center justify-between pl-4 pr-8 lg:hidden relative z-40">
           <div className="flex h-full items-center gap-6 pl-[15px]">
-            <Link to="/home" className="flex items-center">
+            <Link to="https://brockcsc.ca" className="flex items-center">
               <img
                 width={75}
                 height={56}
@@ -126,17 +129,27 @@ export default function Nav() {
               />
             </Link>
             <Link to="/links">
-              <button className="ml-8 inline-flex items-center justify-center bg-[#aa3b3b] px-6 py-1.5 text-base font-medium text-[rgba(255,255,255,0.9)] transition-colors duration-200 hover:bg-[#8e3232]">
+              <button className="ml-8 inline-block bg-[#aa3b3b] px-10 pt-1.5 pb-2 text-base font-normal text-[rgba(255,255,255,0.9)] cursor-pointer hover:bg-[#8e3232] leading-[18.4px] transition-[background-color] duration-200" style={{ boxSizing: 'content-box', fontFamily: 'sans-serif', transitionTimingFunction: 'cubic-bezier(0.35, 0, 0.25, 1)' }}>
                 Join
               </button>
             </Link>
           </div>
           <button
-            className="relative h-12 w-12 shrink-0 p-3"
+            className="relative inline-block cursor-pointer text-center z-40"
             type="button"
             aria-label="Toggle navigation menu"
             aria-expanded={showOverlay}
             onClick={() => setShowOverlay((prev) => !prev)}
+            style={{ 
+              boxSizing: 'content-box',
+              fontFamily: 'Lato, sans-serif',
+              fontSize: '16px',
+              fontWeight: 400,
+              lineHeight: '25px',
+              height: '15px',
+              width: '20px',
+              perspective: '40px'
+            }}
           >
             <span className="sr-only">Open menu</span>
             <span className="relative block h-full w-full">

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -231,7 +231,7 @@ export default function Home() {
           </div>
 
           {/* Actions */}
-          <div className="actions pt-6 max-w-md">
+          <div className="actions pt-6 pb-8 md:pb-0 max-w-md">
             <button
               onClick={() => {
                 setOrderItem({


### PR DESCRIPTION
This pull request makes several visual and structural improvements to the navigation bar component (`Nav.tsx`), focusing on layout consistency, button styling, and link behavior. The changes also include a minor update to spacing in the homepage actions section. The most important changes are grouped below:

### Navigation Bar Layout and Styling Updates:

* Refactored navigation link and button styles to use more consistent spacing, font weights, and sizing, including changes to classes and inline styles for both desktop and mobile views. This includes adjustments to padding, font size, line height, box sizing, and transition timing for buttons and links. 
* Modified the hamburger menu button styling and dimensions, including height, width, and perspective, as well as changing the hamburger line width from 6 to 5 units for improved appearance and alignment. 

### Navigation Link Behavior and Order:

* Reordered the navigation links so that the "Merch" link appears after "Events" and before "CS Guide", improving logical grouping and user experience.
* Updated navigation links to use external URLs (e.g., `https://brockcsc.ca`) for consistency, and fixed the "Join" button link to point to the correct external address. 

### Layout Spacing Adjustments:

* Added inline style for line height to the navigation bar container to improve vertical alignment.
* Updated homepage actions section to include additional bottom padding for better spacing on mobile devices.

### Screenshots:

|Before|After|Main site (if applicable)|
|-|-|-|
|<img width="1236" height="878" alt="image" src="https://github.com/user-attachments/assets/05847261-8d58-414c-9530-777fcaae6aa0" />|<img width="1236" height="878" alt="image" src="https://github.com/user-attachments/assets/e0c336a1-8248-4bd4-a347-177383b92efd" />|<img width="1236" height="879" alt="image" src="https://github.com/user-attachments/assets/a9f56ac8-9dd3-4ee2-9391-44b975cc0106" />|
|<img width="363" height="784" alt="image" src="https://github.com/user-attachments/assets/41bfde00-fcb6-463e-a37a-b675c29a4686" />|<img width="363" height="784" alt="image" src="https://github.com/user-attachments/assets/f19e9dd5-89c5-4650-8ff3-3a8690de2e5d" />||
|<img width="363" height="784" alt="image" src="https://github.com/user-attachments/assets/442fa080-1ae4-4422-9601-2599ef14e284" />|<img width="363" height="784" alt="image" src="https://github.com/user-attachments/assets/eec82c9f-15d7-41df-858d-9d4ed368dee1" />|<img width="363" height="784" alt="image" src="https://github.com/user-attachments/assets/33d8dd4b-12da-4ee8-b826-3742adc10b35" />|